### PR TITLE
modernize elixir cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,8 +8,10 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: centos-6.6
+  - name: centos-6.8
   - name: ubuntu-14.04
+    run_list:
+      - recipe[apt::default]
 
 suites:
   - name: package

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source "https://api.berkshelf.com"
+source 'https://supermarket.chef.io'
 
 metadata

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      "Manages an Elixir installation"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "0.11.0"
 
-depends "apt", "~> 2.7"
+depends "apt", ">= 2.5"
 depends "git"
 depends "github"
 depends "erlang"

--- a/recipes/_package.rb
+++ b/recipes/_package.rb
@@ -8,9 +8,6 @@
 case node['platform_family']
 when 'debian'
   node.normal[:apt][:compile_time_update] = true
-  node.normal[:erlang][:esl][:version] = "1:18.0"
-when 'rhel'
-  node.normal[:erlang][:esl][:version] = "18.0-1.el6"
 end
 
 elixir_path = File.join(node[:elixir][:_versions_path], node[:elixir][:version])

--- a/recipes/_source.rb
+++ b/recipes/_source.rb
@@ -6,9 +6,6 @@
 #
 
 node.set[:erlang][:install_method]    = "source"
-node.set[:erlang][:source][:version]  = "18.0"
-node.set[:erlang][:source][:url]      = "http://erlang.org/download/otp_src_#{node[:erlang][:source][:version]}.tar.gz"
-node.set[:erlang][:source][:checksum] = "1cfbf8acd7702f285d76061b45c128853f47b5e0cdcdf19d51b2ee405075ff11"
 
 include_recipe "erlang::default"
 include_recipe "git::default"


### PR DESCRIPTION
* relax pin on apt cookbook to allow future proofing
* update berksfile to point to supermarket
* remove hardcoded erlang versions
* make sure apt is run on ubuntu platform